### PR TITLE
Precise speed & time elapsed

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -18,6 +18,9 @@ TinyGPSPlus gps;
 SoftwareSerial ss(25, 26);
 byte data[8];
 int lastTime = 0;
+const float kalmanGain = 0.5;
+uint32_t startTime;
+int32_t speed;
 
 class MyServerCallbacks: public BLEServerCallbacks {
   void onConnect(BLEServer* pServer) {
@@ -62,22 +65,25 @@ void loop() {
 
     while (ss.available() > 0) {
       if (gps.encode(ss.read())) {
-        int time = gps.time.value();
+        // int time = gps.time.value();
+        uint32_t time = millis() - startTime;
         int satellites = gps.satellites.value();
-        int speed = gps.speed.knots();
+        speed = kalmanGain * gps.speed.value() + (1 - kalmanGain) * speed;
+
         int alt = gps.altitude.meters();
 
         data[0] = (alt >> 8) & 0xff;
         data[1] = alt & 0xff;
-        data[2] = speed & 0xff;
-        data[3] = satellites & 0xff;
-        data[4] = (time >> 24) & 0xff;
-        data[5] = (time >> 16) & 0xff;
-        data[6] = (time >> 8) & 0xff;
-        data[7] = time & 0xff;
+        data[2] = (speed >> 8) & 0xff;
+        data[3] = speed & 0xff;
+        data[4] = satellites & 0xff;
+        data[5] = (time >> 24) & 0xff;
+        data[6] = (time >> 16) & 0xff;
+        data[7] = (time >> 8) & 0xff;
+        data[8] = time & 0xff;
 
         if (lastTime != time) {
-          pCharacteristic->setValue(data, 8);
+          pCharacteristic->setValue(data, 9);
           pCharacteristic->notify();
           lastTime = time;
         }
@@ -92,6 +98,8 @@ void loop() {
     pServer->startAdvertising();
     Serial.println("start advertising");
     oldDeviceConnected = deviceConnected;
+    startTime = millis();
+    speed = 0;
   }
 
   if (deviceConnected && !oldDeviceConnected) {


### PR DESCRIPTION
GPS raw speed and timer counter instead of clock time.
Multiply by 0,01852 to get km/h with decimal precision